### PR TITLE
Fix expanduser() usage in "Virtual Environment Search Paths" list

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -61,9 +61,10 @@ nova.commands.register("python.resolveEnvs", (workspace) => {
 
     if (!venvDirs) return [];
 
-    for (const dir of venvDirs) {
+    for (let dir of venvDirs) {
+        dir = nova.path.expanduser(dir);
         for (const item of nova.fs.listdir(dir)) {
-            let venvDir = nova.path.expanduser(nova.path.join(dir, item));
+            let venvDir = nova.path.join(dir, item);
             promises.push(utils.checkEnv(venvDir));
         }
     }


### PR DESCRIPTION
While testing the new capability to use `~` in settings, I tried to use it in the "Virtual Environment Search Paths" box, which resulted in an error.

<img width="842" height="294" alt="CleanShot 2026-01-14 at 16 03 21@2x" src="https://github.com/user-attachments/assets/e2a50cdd-8ded-4e86-8472-b1b0cd18aa28" />


I think Nova tries to join e.g. `~/projects/acme` and the name of the file found by `listdir()`, and because `~/projects/acme` is not yet expanded, the directory is not found and an error is raised.

Expanding the `~` before entering `listdir()` loop works, and as a bonus we avoid re-expanding `~` for each sub-dir.